### PR TITLE
Add custom 404 page w/ instructions for missing entries

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,8 +1,12 @@
 ---
 permalink: /404.html
 ---
-Whoops, looks like there isn't a page there.
+**Whoops, looks like there isn't a page there.**
 
 Did you expect to find a glossary entry here? It may be missing because it isn't written yet!
 
-If that's the case, you may want to review the [issues](https://github.com/codeunion/glossary.codeunion.io/issues) for this repository to see if the entry has been requested and/or is under development. Feel free to request a glossary entry by adding an issue yourself!
+If that's the case, you may want to review the [issues](https://github.com/codeunion/glossary.codeunion.io/issues) for this repository to see if the entry has been requested and/or is under development. Feel free to request a glossary entry by adding an issue yourself.
+
+For example, you could add an issue titled `Regular expression` and supply any helpful guiding instructions for what you'd like the entry to cover, such as:
+
+> Please include description of special characters, groups, and flags.

--- a/404.md
+++ b/404.md
@@ -1,0 +1,8 @@
+---
+permalink: /404.html
+---
+Whoops, looks like there isn't a page there.
+
+Did you expect to find a glossary entry here? It may be missing because it isn't written yet!
+
+If that's the case, you may want to review the [issues](https://github.com/codeunion/glossary.codeunion.io/issues) for this repository to see if the entry has been requested and/or is under development. Feel free to request a glossary entry by adding an issue yourself!


### PR DESCRIPTION
Direct visitors to issues page in case of missing entries.

Use 404 to funnel awareness of missing glossary entries into issues on the repo so that they are tracked.
